### PR TITLE
feat: add GitHub PR review status display

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "simple-statusline",
       "description": "A simple, hackable two-line statusline showing model, git status, context usage, and rate limits",
-      "version": "1.3.3",
+      "version": "1.4.0",
       "source": {
         "source": "url",
         "url": "https://github.com/Postmodum37/simple-claude-code-statusline.git"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-statusline",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "A simple, hackable two-line statusline for Claude Code showing model, git status, context usage, and rate limits",
   "author": {
     "name": "Tomas Novikovas",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,8 @@ Claude Code pipes JSON to the script containing:
 - `session_id` - For session duration tracking
 
 The script outputs two lines of ANSI-escaped text:
-1. Model | Directory | Git branch + status
-2. Context bar | 5h rate limit | 7d rate limit | Duration
+1. Model | Directory | Git branch + status | PR status | Lines changed
+2. Context bar | 5h rate limit | 7d rate limit | Cost | Duration
 
 ## Testing
 
@@ -43,6 +43,7 @@ The script uses:
 - `jq` - JSON parsing (required)
 - `curl` - Rate limit API calls
 - `git` - Repository status
+- `gh` - GitHub CLI for PR status (optional - PR status hidden if not installed)
 - macOS `security` command - OAuth token retrieval from keychain
 - Platform-specific: `stat -f %m` (macOS) or `stat -c %Y` (Linux) for cache age
 - Platform-specific: `date -j -f` (macOS) or `date -d` (Linux) for ISO date parsing
@@ -50,7 +51,7 @@ The script uses:
 ## Key Implementation Notes
 
 - Uses `--no-optional-locks` with git commands to avoid conflicts
-- Caches to `${CLAUDE_CODE_TMPDIR:-/tmp}/claude-*` (rate limit: 60s TTL, 15s for errors; git: 5s TTL)
+- Caches to `${CLAUDE_CODE_TMPDIR:-/tmp}/claude-*` (rate limit: 60s TTL, 15s for errors; git: 5s TTL; PR: 30s TTL)
 - Colors use Tokyo Night palette defined at top of script
 - Compatible with bash 3.2 (macOS default) - uses `=~` without capture groups to avoid `BASH_REMATCH`
 - Cross-platform: auto-detects macOS vs Linux for stat/date commands


### PR DESCRIPTION
## Summary
- Add PR review status display to the statusline (row 1, after git branch)
- Shows colored dot + label: `● approved`, `● changes`, `● pending`, `◌ draft`, `● merged`
- Uses `gh pr view` to fetch status, cached for 30 seconds
- Gracefully hidden when `gh` CLI is not installed or no PR exists

## Test plan
- [ ] Verify PR status appears on the statusline when on a branch with a PR
- [ ] Verify correct colors: green (approved/merged), yellow (pending), red (changes), gray (draft)
- [ ] Verify no PR status shown when `gh` is not installed
- [ ] Verify no PR status shown when branch has no associated PR

🤖 Generated with [Claude Code](https://claude.ai/code)